### PR TITLE
Upgraded to socket.io-adapter@0.4.x, fixed compatibility with it

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,25 +259,25 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
 
         self.connected.done(function(amqpChannel)
         {
+            var needToSubscribe = !self.rooms[room];
             Adapter.prototype.add.call(self, id, room);
             var channel = prefix + '#' + self.nsp.name + '#' + room + '#';
 
-            amqpChannel.bindQueue(self.amqpIncomingQueue, self.amqpExchangeName, channel, {}, function (err)
+            if (needToSubscribe)
             {
-                if (err)
-                {
-                    self.emit('error', err);
-                    if (fn)
-                    {
-                        fn(err);
+                amqpChannel.bindQueue(self.amqpIncomingQueue, self.amqpExchangeName, channel, {}, function(err) {
+                    if (err) {
+                        self.emit('error', err);
+                        if (fn) {
+                            fn(err);
+                        }
+                        return;
                     }
-                    return;
-                }
-                if (fn)
-                {
-                    fn(null);
-                }
-            });
+                    if (fn) {
+                        fn(null);
+                    }
+                });
+            }
         });
     };
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "socket.io-adapter": "0.4.x",
-    "amqplib": "0.3.x",
+    "amqplib": "0.4.x",
     "debug":"2.1.x",
     "underscore":"1.6.x",
     "msgpack-js":"0.3.x",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "mocha test/*.js"
   },
   "dependencies": {
-    "socket.io-adapter": "0.3.x",
+    "socket.io-adapter": "0.4.x",
     "amqplib": "0.3.x",
     "debug":"2.1.x",
     "underscore":"1.6.x",


### PR DESCRIPTION
Also upgraded amqplib to 0.4.x for node 4/5 compatibility

https://github.com/squaremo/amqp.node/blob/master/CHANGELOG.md

One of the main compatibility pain points was around the managing of the internal sids and rooms structure. This relies on the underlying socket.io-adapter instance to do that work for us so we can focus mainly on just the amqplib code. 

This follows a lot of the work I did on this project: https://github.com/GannettDigital/socket.io-ioredis

This also addresses issues discussed in https://github.com/socketio/socket.io/issues/2378
