### PR TITLE
Added ability to specify the unique queue name

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
     opts = opts || {};
 
     underscore.defaults(opts, {
+        queueName: '',
         prefix: ''
     });
 
@@ -134,7 +135,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
                                 autoDelete: true
                             };
 
-                            amqpChannel.assertQueue('', incomingMessagesQueue, function (err, queue)
+                            amqpChannel.assertQueue(opts.queueName, incomingMessagesQueue, function (err, queue)
                             {
                                 if (err)
                                 {


### PR DESCRIPTION
We're sharing a rabbitmq cluster with other people, need a way to specify the queue name instead of using the auto-generated queue name so the auditors know which queue belongs to what subsystem.
