### PR TITLE
Added option to customize the channel seperator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
-
+node_modules
+npm-debug.log
 *~

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The following options are allowed:
 
 - `prefix`: A prefix that will be applied to all queues, exchanges and messages created by socket.io-amqp.
 
+- `queueName`: The name of the rabbitmq queue to use listen in on the exchange. Must be unique. Default value is '' which means rabbitmq will auto generate a queue name for you that is unique.
+
+- `channelSeperator`: The delimiter between the prefix, the namespace name, and the room, the default is '#' for compatibility with socket.io-emitter, but if you don't use it,**you should change it because # is a wildcard character in rabbitmq which means you may get cross chatter with other rooms**.
+
 - `onNamespaceInitializedCallback`: This is a callback function that is called everytime sockets.io opens a new namespace. Because a new namespace requires new queues and exchanges, you can get a callback to indicate the success or failure here. This callback should be in the form of function(err, nsp), where err is the error, and nsp is the namespace. If your code needs to wait until sockets.io is fully set up and ready to go, you can use this.
 
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
 
     underscore.defaults(opts, {
         queueName: '',
+        channelSeperator: '#',
         prefix: ''
     });
 
@@ -147,7 +148,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
                                 {
                                     self.amqpIncomingQueue = queue.queue;
 
-                                    self.globalRoomName = prefix + '#' + self.nsp.name + '#';
+                                    self.globalRoomName = getChannelName(prefix, self.nsp.name);
                                     amqpChannel.bindQueue(self.amqpIncomingQueue, self.amqpExchangeName, self.globalRoomName, {}, function (err)
                                     {
                                         if (err)
@@ -262,7 +263,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
         {
             var needToSubscribe = !self.rooms[room];
             Adapter.prototype.add.call(self, id, room);
-            var channel = prefix + '#' + self.nsp.name + '#' + room + '#';
+            var channel = getChannelName(prefix, self.nsp.name, room);
 
             if (needToSubscribe)
             {
@@ -302,7 +303,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
             {
                 opts.rooms.forEach(function (room)
                 {
-                    var chn = prefix + '#' + packet.nsp + '#' + room + '#';
+                    var chn = getChannelName(prefix, packet.nsp, room);
                     var msg = msgpack.encode([self.amqpConsumerID, packet, opts]);
                     amqpChannel.publish(self.amqpExchangeName, chn, msg);
                 });
@@ -335,7 +336,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
             Adapter.prototype.del.call(self, id, room);
             if (!self.rooms[room])
             {
-                var channel = prefix + '#' + self.nsp.name + '#' + room + '#';
+                var channel = getChannelName(prefix, self.nsp.name, room);
 
                 amqpChannel.unbindQueue(self.amqpIncomingQueue, self.amqpExchangeName, channel, {}, function (err)
                 {
@@ -393,7 +394,7 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
             {
                 if (!self.rooms[room])
                 {
-                    var channel = prefix + '#' + self.nsp.name + '#' + room + '#';
+                    var channel = getChannelName(prefix, self.nsp.name, room);
 
                     amqpChannel.unbindQueue(self.amqpIncomingQueue, self.amqpExchangeName, channel, {}, function (err)
                     {
@@ -431,6 +432,10 @@ function adapter (uri, opts, onNamespaceInitializedCallback)
             });
         });
     };
+
+    function getChannelName() {
+        return Array.prototype.join.call(arguments, opts.channelSeperator) + opts.channelSeperator;
+    }
 
     return AMQPAdapter;
 


### PR DESCRIPTION
The purpose of this is to avoid using rabbitmq's wildcard character documented here: 

https://www.rabbitmq.com/tutorials/tutorial-five-python.html

I've left it as # for now for backwards compatibility, but updated the README to point out why it's bad to leave the default. 
