### PR TITLE
Add support to pass amqpConnectionOptions through the init options

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = adapter;
  * @param {String}  uri AMQP uri
  * @param {Object}  opts  Options for the connection.
  * @param {String}  [opts.queueName='']
- * @param {String}  [opts.channelSeperator='#']
+ * @param {String}  [opts.channelSeparator='#']
  * @param {String}  [opts.prefix='']
  * @param {Boolean} [opts.useInputExchange=false]
  * @param {Object}  [opts.amqpConnectionOptions={}]
@@ -71,7 +71,7 @@ function adapter(uri, opts, onNamespaceInitializedCallback)
 
     underscore.defaults(opts, {
         queueName: '',
-        channelSeperator: '#',
+        channelSeparator: '#',
         prefix: '',
         useInputExchange: false,
         amqpConnectionOptions: {},
@@ -394,7 +394,7 @@ function adapter(uri, opts, onNamespaceInitializedCallback)
 
     function getChannelName()
     {
-        return Array.prototype.join.call(arguments, opts.channelSeperator) + opts.channelSeperator;
+        return Array.prototype.join.call(arguments, opts.channelSeparator) + opts.channelSeparator;
     }
 
     return AMQPAdapter;

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = adapter;
  * @param {String}  [opts.channelSeperator='#']
  * @param {String}  [opts.prefix='']
  * @param {Boolean} [opts.useInputExchange=false]
+ * @param {Object}  [opts.amqpConnectionOptions={}]
  * @param {function} onNamespaceInitializedCallback This is a callback function that is called everytime sockets.io opens a
  *                                     new namespace. Because a new namespace requires new queues and exchanges,
  *                                     you can get a callback to indicate the success or failure here. This
@@ -72,7 +73,8 @@ function adapter(uri, opts, onNamespaceInitializedCallback)
         queueName: '',
         channelSeperator: '#',
         prefix: '',
-        useInputExchange: false
+        useInputExchange: false,
+        amqpConnectionOptions: {},
     });
 
     const prefix = opts.prefix;
@@ -88,7 +90,7 @@ function adapter(uri, opts, onNamespaceInitializedCallback)
     {
         Adapter.call(this, nsp);
 
-        const amqpConnectionOptions = {};
+        const amqpConnectionOptions = opts.amqpConnectionOptions;
 
         const amqpExchangeOptions = {
             durable: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io-amqp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Sockets.IO Adapter for AMQP & RabbitMQ",
   "main": "lib/main.js",
   "directories": {


### PR DESCRIPTION
Allow passing `amqpConnectionOptions` to the constructor function options object.

This is necessary to enable control of specific connection parameters.