### PR TITLE
Improve documentation for `channelSeperator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following options are allowed:
 
 - `queueName`: The name of the rabbitmq queue to use listen in on the exchange. Must be unique. Default value is '' which means rabbitmq will auto generate a queue name for you that is unique.
 
-- `channelSeperator`: The delimiter between the prefix, the namespace name, and the room, the default is '#' for compatibility with socket.io-emitter, but if you don't use it,**you should change it because # is a wildcard character in rabbitmq which means you may get cross chatter with other rooms**.
+- `channelSeperator`: The delimiter between the prefix, the namespace name, and the room. The default is '#' for consistency with socket.io-emitter and backwards compatibility with older versions of `socket.io-amqp`. If you are using the library for the first time, **you should change it because # is a wildcard character in rabbitmq which means you may get cross chatter with other rooms**. If you have used the library previously and do not interact with the messages publshed to the exchanges created by `socket.io-amqp` based on routing key, you should also change the separator.
 
 - `onNamespaceInitializedCallback`: This is a callback function that is called everytime sockets.io opens a new namespace. Because a new namespace requires new queues and exchanges, you can get a callback to indicate the success or failure here. This callback should be in the form of function(err, nsp), where err is the error, and nsp is the namespace. If your code needs to wait until sockets.io is fully set up and ready to go, you can use this.
 


### PR DESCRIPTION
The documentation doesn't make all that much sense to me as it is. I took a look at the source code and didn't understand how there are comparability issues with `socket.io-emitter`, but do understand that the name provides _consistency_.

When added by @fracmak in https://github.com/sensibill/socket.io-amqp/pull/5, it seemed as well that the reason for not changing it was purely backwards compatibility.